### PR TITLE
ci(dependabot): restore cargo PR limit so security PRs flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,14 @@ updates:
     # `ignore: "*" patch` rule also silenced security PRs under GitHub\'s
     # current Dependabot behaviour. See rsr-template-repo commit 78b050e
     # and 007-lang/audits/audit-dependabot-automation-gap-2026-04-17.md.
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10
+    groups:
+      cargo:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Propagates rsr-template-repo#37 fix. `open-pull-requests-limit: 0` on the cargo block was empirically suppressing Dependabot **security** PRs estate-wide (not just version updates as the previous comment claimed). Restoring to `10` with grouped minor/patch updates to keep noise contained while letting security advisories flow.