### PR TITLE
ci(rust): convert rust-ci.yml to thin wrapper (standards#174)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,53 +1,20 @@
 # SPDX-License-Identifier: MPL-2.0
+# Rust CI — thin wrapper calling the shared estate reusable in
+# hyperpolymath/standards. Configure once, propagate everywhere.
+# See: docs/CI-REUSABLE-WORKFLOWS.adoc in standards.
 name: Rust CI
-on: [push, pull_request]
-env:
-  CARGO_TERM_COLOR: always
-  RUSTFLAGS: -Dwarnings
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
-      
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-      
-      - name: Clippy lints
-        run: cargo clippy --all-targets --all-features -- -D warnings
-      
-      - name: Run tests
-        run: cargo test --all-features
-      
-      - name: Build release
-        run: cargo build --release
-
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-      - name: Security audit
-        run: cargo audit
-      - name: Check for outdated deps
-        run: cargo install cargo-outdated && cargo outdated --exit-code 1 || true
-
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install tarpaulin
-        run: cargo install cargo-tarpaulin
-      - name: Generate coverage
-        run: cargo tarpaulin --out Xml
-      - uses: codecov/codecov-action@v6
-        with:
-          files: cobertura.xml
+  rust-ci:
+    uses: hyperpolymath/standards/.github/workflows/rust-ci-reusable.yml@4fdf4314b4ab54269adbaff10e30e483b5e86845
+    with:
+      enable_audit: true
+      enable_coverage: true


### PR DESCRIPTION
## Summary

Replaces the per-repo `rust-ci.yml` copy with a 5-line wrapper invoking the shared reusable workflow filed in [standards#174](https://github.com/hyperpolymath/standards/pull/174).

Pinned to that PR's HEAD SHA (`4fdf4314b4ab54269adbaff10e30e483b5e86845`); will resolve to standards/main once #174 merges.

## Why

Estate audit found ~87 `rust-ci.yml` copies across the estate with significant drift. Converting each to a 5-line wrapper means future Rust CI changes propagate in one place.

This PR is part of the foundational sweep following the established [standards#168](https://github.com/hyperpolymath/standards/pull/168) precedent (governance-reusable + absolute-zero#41 + tma-mark2#41 wrappers).

Variant: **audit-cov** ("opts into cargo-audit + coverage")

## Test plan

- [ ] CI: `rust-ci` job invokes the reusable and reports the same checks
- [ ] Awaiting standards#174 merge before this becomes useful long-term (still works today via SHA pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)