### PR TITLE
ci(rust): convert rust-ci.yml to thin wrapper (standards#174)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,53 +1,20 @@
 # SPDX-License-Identifier: MPL-2.0
+# Rust CI — thin wrapper calling the shared estate reusable in
+# hyperpolymath/standards. Configure once, propagate everywhere.
+# See: docs/CI-REUSABLE-WORKFLOWS.adoc in standards.
 name: Rust CI
-on: [push, pull_request]
-env:
-  CARGO_TERM_COLOR: always
-  RUSTFLAGS: -Dwarnings
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
-      
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-      
-      - name: Clippy lints
-        run: cargo clippy --all-targets --all-features -- -D warnings
-      
-      - name: Run tests
-        run: cargo test --all-features
-      
-      - name: Build release
-        run: cargo build --release
-
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-      - name: Security audit
-        run: cargo audit
-      - name: Check for outdated deps
-        run: cargo install cargo-outdated && cargo outdated --exit-code 1 || true
-
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install tarpaulin
-        run: cargo install cargo-tarpaulin
-      - name: Generate coverage
-        run: cargo tarpaulin --out Xml
-      - uses: codecov/codecov-action@v6
-        with:
-          files: cobertura.xml
+  rust-ci:
+    uses: hyperpolymath/standards/.github/workflows/rust-ci-reusable.yml@4fdf4314b4ab54269adbaff10e30e483b5e86845
+    with:
+      enable_audit: true
+      enable_coverage: true


### PR DESCRIPTION
Replaces the per-repo `rust-ci.yml` copy with a 5-line wrapper invoking the shared reusable workflow in `hyperpolymath/standards` (PR #174).

Pinned to PR #174's HEAD SHA `4fdf4314b4ab54269adbaff10e30e483b5e86845`; will resolve to standards/main once #174 merges.

Estate audit found ~87 rust-ci.yml copies across the estate; this is one of them. The reusable provides identical cargo check/clippy/fmt/test behaviour with opt-in `enable_audit` + `enable_coverage` inputs.

Pattern precedent: standards#168 (governance-reusable) + downstream wrappers absolute-zero#41 + tma-mark2#41.

## Description

<!-- Provide a brief description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test addition/improvement
- [ ] CI/CD improvement
- [ ] Security fix

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close issues when merged -->

Closes #

## Changes Made

<!-- Provide a detailed list of changes -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Manual testing completed

### Test Commands Run

```bash
# Add commands you ran to test
pytest tests/ -v
```

### Test Results

<!-- Paste relevant test output -->

## Checklist

### Code Quality

- [ ] Code follows the project's style guidelines
- [ ] Code is formatted with `black`
- [ ] Imports are organized with `isort`
- [ ] Linting passes (`flake8`)
- [ ] Type hints added where applicable
- [ ] Docstrings added/updated for public functions

### Testing

- [ ] All tests pass locally
- [ ] New tests cover the changes
- [ ] Test coverage has not decreased
- [ ] Edge cases are tested

### Documentation

- [ ] README updated (if needed)
- [ ] API documentation updated (if needed)
- [ ] CHANGELOG.md updated
- [ ] Code comments added for complex logic
- [ ] Examples provided (if adding new feature)

### Security

- [ ] No hardcoded secrets or credentials
- [ ] Input validation implemented
- [ ] No new security vulnerabilities introduced
- [ ] Security implications considered and documented
- [ ] Ethical use guidelines followed

### RSR Compliance

- [ ] Changes maintain offline-first operation
- [ ] No unnecessary network calls added
- [ ] Dependencies pinned with versions (if added)
- [ ] Security policy considered

### Legal & Ethical

- [ ] Changes comply with GPL-3.0 license
- [ ] Changes support only authorized use
- [ ] No malicious code included
- [ ] Ethical hacking principles followed

## Screenshots/Output

<!-- If applicable, add screenshots or example output -->

```
# Paste example output here
```

## Performance Impact

<!-- Describe any performance implications -->

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance benchmarks run (paste results)

## Breaking Changes

<!-- List any breaking changes and migration steps -->

None / N/A

## Additional Notes

<!-- Add any additional context or notes for reviewers -->

## Reviewer Checklist

<!-- For maintainers reviewing this PR -->

- [ ] Code review completed
- [ ] Security implications reviewed
- [ ] Tests reviewed and adequate
- [ ] Documentation reviewed
- [ ] Breaking changes assessed
- [ ] Performance impact acceptable
- [ ] Ethical use compliance verified

---

**By submitting this PR, I confirm that:**
- I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- My changes are for authorized, ethical security testing purposes only
- I agree to license my contributions under GPL-3.0
